### PR TITLE
v0.3: Change name and format of multibag tag files

### DIFF
--- a/docs/multibag-profile-spec.md
+++ b/docs/multibag-profile-spec.md
@@ -55,7 +55,7 @@ non-destructive updates leverages this feature.  A bag can only be the
 Head Bag for one Multibag aggregation.
 
 <a name="Bag_and_File_Name_Restrictions"></a>
-###
+### Bag and File Name Restrictions
 
 _This section is normative._
 
@@ -251,4 +251,6 @@ Multibag component was spun off to create its verison 0.2.
        filenames and bagnames.  
      * The base names were changed as some reviewers found the names
        not obvious as to their purpose.
-
+   * The format change for the above mentioned tag files necessitated
+     adding restrictions on the names of the component bags and the
+     files that appear under the data directory.  


### PR DESCRIPTION
In v0.2, the format of the multibag tag files `group-members.txt` and `group-directory.txt` were ambiguous when the file names and or the bag name contains spaces.  This PR introduces v0.3 which changes the format of these files to TSV.  The names have also been changed to `member-bags.tsv` and `filelookup.tsv`, respectively.  The change to TSV necessitated restricting file and bagnames to be compliant: they cannot contain tab characters, nor can they contain spaces at the beginning or end of the name.  