### PR TITLE
Enable splitting strategies

### DIFF
--- a/multibag/split.py
+++ b/multibag/split.py
@@ -476,6 +476,10 @@ class SplitPlan(object):
     """
     a description of how to distribute the payload and metadata files 
     from a progenitor bag across multiple output multibags.  
+
+    The plan is specific to a given source bag, and when it's complete, it 
+    can be applied to the source bag to create the output multibags via 
+    the `apply_iter()` function.  
     """
 
     def __init__(self, source):
@@ -784,6 +788,13 @@ class Splitter(object):
     """
     an abstract class for algorithms that can create a SplitPlan given a 
     source bag.  
+
+    A Splitter subclass captures a particular strategy for distributing the 
+    files found in a source bag into a set of output multibags.  To create a
+    Splitter implementation, one would subclass this abstract base class and 
+    over-ride the abstract `_create_plan()` function.  This function captures
+    the essential logic of the strategy and uses it to create SplitPlan tailored
+    to a given source bag.  
     """
     __metaclass__ = ABCMeta
 

--- a/multibag/split.py
+++ b/multibag/split.py
@@ -6,6 +6,7 @@ import os, sys, re, shutil
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from copy import deepcopy
+from functools import cmp_to_key
 
 from .access.bagit import Bag, ReadOnlyBag
 from bagit import _parse_tags
@@ -987,7 +988,7 @@ class WellPackedSplitter(Splitter):
                        if not f.is_dir and not self._is_special(p)
                                        and p not in self.forhead]
                           
-        finfos.sort(self._cmp_by_size)
+        finfos.sort(key=cmp_to_key(self._cmp_by_size))
         return finfos
 
 class NeighborlySplitter(WellPackedSplitter):

--- a/multibag/split.py
+++ b/multibag/split.py
@@ -977,10 +977,11 @@ class WellPackedSplitter(Splitter):
     @staticmethod
     def _cmp_by_size(infoa, infob):
         # we want sort to descend in size
-        out = cmp(infob['size'], infoa['size'])
+        out = infob['size'] - infoa['size']
         if out != 0:
             return out
-        return cmp(infoa['path'], infob['path'])
+        return ((infoa['path'] < infob['path']) and -1) or \
+               ((infoa['path'] > infob['path']) and +1) or 0
 
     def _sorted_files(self, bag):
         finfos = [{"path": p, "size": f.size, "name": p.split('/')[-1]}

--- a/tests/multibag/test_split.py
+++ b/tests/multibag/test_split.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 import os, pdb, logging
 import tempfile, shutil
 import unittest as test
+from functools import cmp_to_key
 
 import multibag.split as split
 from multibag.access.bagit import Bag, ReadOnlyBag, Path, open_bag
@@ -583,7 +584,7 @@ class TestNeighborlySplitter(test.TestCase):
 
     def test_cmp_by_size(self):
         self.spltr = split.NeighborlySplitter()
-        self.info.sort(self.spltr._cmp_by_size)
+        self.info.sort(key=cmp_to_key(self.spltr._cmp_by_size))
         sz = 0
         for fi in reversed(self.info):
             self.assertGreaterEqual(fi['size'], sz)
@@ -593,7 +594,7 @@ class TestNeighborlySplitter(test.TestCase):
         self.spltr = split.NeighborlySplitter(2200, 2000)
         self.info = [f for f in self.info
                        if not self.spltr._is_special(f['path'])]
-        self.info.sort(self.spltr._cmp_by_size)
+        self.info.sort(key=cmp_to_key(self.spltr._cmp_by_size))
         bag = ReadOnlyBag(self.bagdir)
         plan = split.SplitPlan(bag)
         self.spltr._apply_algorithm(self.info, plan)
@@ -702,7 +703,7 @@ class TestWellPackedSplitter(test.TestCase):
     def test_apply_algorithm(self):
         self.info = [f for f in self.info
                        if not self.spltr._is_special(f['path'])]
-        self.info.sort(self.spltr._cmp_by_size)
+        self.info.sort(key=cmp_to_key(self.spltr._cmp_by_size))
         bag = ReadOnlyBag(self.bagdir)
         plan = split.SplitPlan(bag)
         self.spltr._apply_algorithm(self.info, plan)


### PR DESCRIPTION
This PR advances the bag splitting implementation provided by [`multibag.split`](../multibag/split.py) adding the `Splitter` class.  This abstract class provides an interface--namely `Splitter.plan()`--for applying a particular strategy for dividing files from the source bag into the different output multibags.  Two implementations are provided in the module, but the user may implement their own.  

The `WellPackedSplitter` implementation attempts to pack the files from the source bag into as few output multibags, each under a given size limit.  The `NeighborlySplitter` adds an additional goal of trying to keep files that are close together in the source bag's file hierarchy in the same output multibag.  
 