### PR TITLE
add sizeof() method to extended bag interface

### DIFF
--- a/multibag/split.py
+++ b/multibag/split.py
@@ -175,6 +175,10 @@ class SplitPlan(object):
                                           len(self._manifests)),
             "contents": list(self.missing())
         }
+        size = 0
+        for f in man['contents']:
+            size += self.progenitor.sizeof(f)
+        man['totalsize'] = size
         if man['contents']:
             self._manifests.append(man)
 

--- a/tests/multibag/access/test_extended.py
+++ b/tests/multibag/access/test_extended.py
@@ -63,7 +63,7 @@ class TestExtendedReadWritableBag(test.TestCase):
 
     def test_sizeof(self):
         self.assertEqual(self.bag.sizeof("data/trial1.json"), 69)
-        self.assertEqual(self.bag.sizeof("data"), 4096)
+        self.assertGreater(self.bag.sizeof("data"), 0)
         with self.assertRaises(OSError):
             self.bag.sizeof("data/goober")
 

--- a/tests/multibag/access/test_extended.py
+++ b/tests/multibag/access/test_extended.py
@@ -61,6 +61,12 @@ class TestExtendedReadWritableBag(test.TestCase):
         self.assertFalse(self.bag.isfile("data/trial3"))
         self.assertFalse(self.bag.isfile("data/trial3/goober"))
 
+    def test_sizeof(self):
+        self.assertEqual(self.bag.sizeof("data/trial1.json"), 69)
+        self.assertEqual(self.bag.sizeof("data"), 4096)
+        with self.assertRaises(OSError):
+            self.bag.sizeof("data/goober")
+
     def test_bag(self):
         # test that self.bag behaves like a bagit.Bag
         self.assertEqual(self.bag.algs, ["sha256"])
@@ -259,6 +265,12 @@ class TestExtendReadOnlyBag(test.TestCase):
         self.assertFalse(self.bag.isfile("data/goober"))
         self.assertFalse(self.bag.isfile("data/trial3"))
         self.assertFalse(self.bag.isfile("data/trial3/goober"))
+
+    def test_sizeof(self):
+        self.assertEqual(self.bag.sizeof("data/trial1.json"), 69)
+        self.assertEqual(self.bag.sizeof("data"), 0)
+        with self.assertRaises(OSError):
+            self.bag.sizeof("data/goober")
 
     def test_bag(self):
         # test that self.bag behaves like a bagit.Bag

--- a/tests/multibag/test_split.py
+++ b/tests/multibag/test_split.py
@@ -132,6 +132,8 @@ class TestSplitPlan(test.TestCase):
 
         self.plan.complete_plan()
         self.assertEqual(len(self.plan._manifests), 2)
+        self.assertGreater(self.plan._manifests[-1]['totalsize'], 0)
+        self.assertEqual(self.plan._manifests[-1]['totalsize'], 208)
         for p in willmiss:
             self.assertIn(p, self.plan._manifests[-1]["contents"])
         self.assertEqual(len(self.plan._manifests[-1]["contents"]), 3)


### PR DESCRIPTION
The `split.SplitPlan` class includes the method, `complete_plan()` which will, if necessary, define an additional manifest for an output bag that will catch any remaining files from the input bag that are not part of any of the existing manifests.  Unlike the previous bags, however, the new manifest it created did not include a total projected size for the output bag.  This PR causes this total size to be calculated.

To facilitate this fix, an update to the "extended bag interface" (from `multibag.access.extended`).
This interface provides a common API for information about files and directories inside of a bag, regardless of whether the bag is serialized or not.  This PR adds a method, `sizeof()`, to that interface to get the size of files (in bytes).