### PR TITLE
improve multibag usage/workflow

### DIFF
--- a/multibag/__init__.py
+++ b/multibag/__init__.py
@@ -9,8 +9,11 @@ specification. The HeadBag class is Multibag specialization specifically for
 head bags which can be used to reconstitute the progenitor bag.  
 """
 from .split import Splitter, WellPackedSplitter, NeighborlySplitter, SplitPlan
-from .access.multibag import HeadBag, as_headbag
-from .access.bagit import open_bag
+from .access.multibag import HeadBag, as_headbag, is_headbag, open_headbag
+from .access.bagit import open_bag, BagError, BagValidationError
+from .validate import (MultibagValidationError, HeadBagValidator,
+                       MemberBagValidator, validate_headbag, validate_memberbag)
+from .amend import SingleMultibagMaker
 
 
 

--- a/multibag/access/bagit.py
+++ b/multibag/access/bagit.py
@@ -621,7 +621,7 @@ def open_bag(location):
         fspath = Path(fs.open_fs(location), "", location+':')
 
     elif not os.path.exists(location):
-        raise OSError(2, "File not found: "+location, location)
+        raise OSError(2, "File not found: "+location)
 
     elif os.path.isdir(location):
         # it's a unserialized bag on local disk

--- a/multibag/split.py
+++ b/multibag/split.py
@@ -63,7 +63,7 @@ class SplitPlan(object):
                         source bag.
         :type str or Bag:
         """
-        if isinstance(source, str):
+        if isinstance(source, (str, _unicode)):
             if os.path.isfile(source):
                 source = ReadOnlyBag(source)
             else:

--- a/tests/multibag/test_split.py
+++ b/tests/multibag/test_split.py
@@ -33,9 +33,6 @@ class TestSplitPlan(test.TestCase):
         self.assertEqual(self.plan._manifests, [])
         self.assertIs(self.plan.progenitor, self.bag)
 
-        with self.assertRaises(ValueError):
-            split.SplitPlan(self.bagdir)
-
     def test_is_complete(self):
         self.assertFalse(self.plan.is_complete())
 


### PR DESCRIPTION
These sundry improvements came as a result of using the library in the NIST Public Data Repository.  The unifying theme is improving the way one updates and save the metadata that gets written to the `multibag` tag directory.  Additional methods were added to the Multibag interface for removing entries to the multibag files (which is needed when ensuring, e,g,, that `member-bags.tsv` contains a unique list of bag names).  Also, the `split` module allows the source bag to be a head-bag itself; in this case, we need to preserve the multibag metadata that's already stored there.  

