### PR TITLE
Allow for unicode in bag metadata

### DIFF
--- a/multibag/split.py
+++ b/multibag/split.py
@@ -2,7 +2,7 @@
 Tools for splitting a single bag (a ProgenitorBag) into a set of 
 Multibag-compliant bags.
 """
-import os, sys, re, shutil, codecs
+import os, sys, re, shutil, io
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from copy import deepcopy
@@ -239,7 +239,7 @@ class SplitPlan(object):
             if not isinstance(vals, list):
                 vals = [vals]
             for v in vals:
-                fd.write("%s: %s\n" % (key,v))
+                fd.write(u"%s: %s\n" % (key,v))
             
 
         # multibag tag info; initialize from the progenitor bag if the
@@ -333,7 +333,7 @@ class SplitPlan(object):
                     
             # create the bag-info file
             outinfo = os.path.join(bagdir, "bag-info.txt")
-            with open(outinfo, 'w') as fd:
+            with io.open(outinfo, 'w', encoding='utf-8') as fd:
                 _write_item(fd, 'Multibag-Version', MBAG_VERSION)
                 for name, vals in self.progenitor.info.items():
                     if name.startswith('Multibag-'):
@@ -379,14 +379,17 @@ class SplitPlan(object):
                 if not os.path.isdir(mbagdir):
                     os.mkdir(mbagdir)
 
-                with open(os.path.join(mbagdir, "member-bags.tsv"), 'w') as fd:
+                with io.open(os.path.join(mbagdir, "member-bags.tsv"),
+                             'w', encoding='utf-8') as fd:
                     for bag in memberbags:
-                        fd.write(bag)
-                        fd.write('\n')
-                with open(os.path.join(mbagdir, "file-lookup.tsv"), 'w') as fd:
+                        fd.write(u"%s" % bag)
+                        fd.write(u'\n')
+                with io.open(os.path.join(mbagdir, "file-lookup.tsv"),
+                             'w', encoding='utf-8') as fd:
                     for f in filedest:
-                        fd.write("%s\t%s\n" % (f, filedest[f]))
-                with open(os.path.join(mbagdir, "aggregation-info.txt"), 'w') as fd:
+                        fd.write(u"%s\t%s\n" % (f, filedest[f]))
+                with io.open(os.path.join(mbagdir, "aggregation-info.txt"),
+                             'w', encoding='utf-8') as fd:
                     with self.progenitor.open_text_file("bag-info.txt") as ifd:
                         for f in ifd:
                             fd.write(f)
@@ -403,11 +406,11 @@ class SplitPlan(object):
         manpath = os.path.join(outdir, manfile)
         if not os.path.exists(manpath):
             open(manpath, 'w').close()
-        with open(manpath, 'a') as fd:
+        with io.open(manpath, 'a', encoding='utf-8') as fd:
             fd.write(hash)
-            fd.write(' ')
+            fd.write(u' ')
             fd.write(path)
-            fd.write('\n')
+            fd.write(u'\n')
 
 class Splitter(object):
     """

--- a/tests/multibag/access/test_extended.py
+++ b/tests/multibag/access/test_extended.py
@@ -136,6 +136,8 @@ class TestExtendedReadWritableBag(test.TestCase):
         self.assertEqual(contents, [("data/trial3", [], ['trial3a.json'])])
 
         contents = list(self.bag.walk("data"))
+        for d in contents:
+            d[2].sort()
         self.assertEqual(len(contents), 2)
         self.assertEqual(contents[0], ("data", ["trial3"],
                                        ['trial1.json', 'trial2.json']))

--- a/tests/multibag/test_split.py
+++ b/tests/multibag/test_split.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os, pdb, logging
+import os, pdb, logging, io
 import tempfile, shutil
 import unittest as test
 from functools import cmp_to_key
@@ -22,6 +22,13 @@ class TestSplitPlan(test.TestCase):
         shutil.copytree(os.path.join(datadir, "samplembag"), self.bagdir)
         shutil.rmtree(os.path.join(self.bagdir, "multibag"))
         os.mkdir(os.path.join(self.bagdir, "metadata", "trial3"))
+
+        # add a line to the bag-info.txt that will require encoding
+        with io.open(os.path.join(self.bagdir,"bag-info.txt"),
+                     'a', encoding='utf-8') as fd:
+            fd.write(u"Funny-Characters: ")
+            fd.write('ß')
+            fd.write(u"\n")
 
         self.bag = split.asProgenitor(Bag(self.bagdir))
         self.plan = split.SplitPlan(self.bag)


### PR DESCRIPTION
Splitting would fail due to a string encoding error if the source bag metadata (i.e. a value in the `bag-info.txt` file) contained Unicode that couldn't map to ASCII.  This PR fixes this issue and generally allows for Unicode to appear in any of the metadata files.  