### PR TITLE
Bug fix: ensure proper setting and use of profile version:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 install:
   - pip install -r requirements.txt
 

--- a/multibag/access/extended.py
+++ b/multibag/access/extended.py
@@ -574,9 +574,12 @@ class _ExtendedReadOnlyMixin(ExtendedReadMixin):
 
         witer = root.fs.walk.walk()
         while True:
-            base, dirs, files = next(witer)
-            base = '/'.join([start, base.lstrip('/')]).strip('/')
-            yield base, [d.name for d in dirs], [f.name for f in files]
+            try: 
+                base, dirs, files = next(witer)
+                base = '/'.join([start, base.lstrip('/')]).strip('/')
+                yield base, [d.name for d in dirs], [f.name for f in files]
+            except StopIteration:  # see PEP0479 for supporting 3.7+
+                return
 
 class ExtendedReadOnlyBag(ReadOnlyBag, _ExtendedReadOnlyMixin):
     """

--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -198,7 +198,7 @@ class HeadBagReadMixin(ExtendedReadMixin):
         MemberInfo instances.
         """
         mbdir = self.info.get('Multibag-Tag-Directory', 'multibag')
-        vers = Version(self.version)
+        vers = Version(self.profile_version)
         membagfile = (vers < "0.3" and "group-members.txt") \
                       or "member-bags.tsv"
         membagpath = "/".join([mbdir, membagfile])

--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -294,7 +294,7 @@ class HeadBagReadMixin(ExtendedReadMixin):
         parseline = parse_deleted_line_04
         delfile = "/".join([self.multibag_tag_dir, 'deleted.txt'])
         if not self.exists(delfile):
-            raise StopIteration()
+            return
         
         with self.open_text_file(delfile) as fd:
             for line in fd:

--- a/multibag/amend.py
+++ b/multibag/amend.py
@@ -194,7 +194,7 @@ class Amender(object):
         :param amendee:   the old head bag of an existing aggregation (or 
                           a single traditional bag)
         :type amendee:    Bag instance or str path to the bag
-        :param str amendment:  a bag that is to become the new of the amended
+        :param str amendment:  a bag that is to become the new head of the amended
                           aggregation.  This must be given as the str path 
                           to the bag's root directory.
         """
@@ -211,15 +211,21 @@ class Amender(object):
         self._comm = comment
         self._info = list(info)
 
-    def init_from_amendee(self):
+    def init_from_amendee(self, keepprofver=False):
         """
         Pull information from the amendee bag to initialize the multibag
         information in the new target head bag.
+
+        :param bool keepprofver:  if True, the profile version for the new 
+                                  target head bag will be set to that of the 
+                                  amendee bag; otherwise (default), it will 
+                                  set to that of the latest version supported 
+                                  by this module.
         """
 
+        self._init_multibag_info(keepprofver)
         self._init_member_bags()
         self._init_file_lookup()
-        self._init_multibag_info()
 
     def _init_member_bags(self):
         target = os.path.join(self._newheaddir, self._newhead.multibag_tag_dir,
@@ -254,7 +260,12 @@ class Amender(object):
             # just add the files under 'data'
             self._newhead.update_for_member(self._oldhead, make_member=False)
 
-    def _init_multibag_info(self):
+    def _init_multibag_info(self, keepprofver=False):
+        profver = CURRENT_VERSION
+        if keepprofver and 'Multibag-Version' in self._oldhead.info:
+            profver = self._oldhead.info['Multibag-Version']
+        self._newhead.info['Multibag-Version'] = profver
+            
         if 'Multibag-Head-Deprecates' in self._oldhead.info:
             if isinstance(self._oldhead.info['Multibag-Head-Deprecates'], list):
                 self._newhead.info['Multibag-Head-Deprecates'] = \
@@ -333,7 +344,7 @@ class Amender(object):
 
         self._newhead.save_member_bags()
         self._newhead.save_file_lookup()
-        self._newhead.update_info(version)
+        self._newhead.update_info(version, self._newhead.profile_version)
 
         
     

--- a/multibag/constants.py
+++ b/multibag/constants.py
@@ -1,28 +1,41 @@
 """
 Common data about the multibag profile.
 """
+import sys
+
 CURRENT_VERSION = "0.4"
 CURRENT_REFERENCE = "https://github.com/usnistgov/multibag-py/blob/master/docs/multibag-profile-spec.md"
 
 DEFAULT_TAG_DIR = "multibag"
+
+if sys.version_info[0] > 2:
+    _unicode = str
+else:
+    _unicode = unicode
+
+def _2int(sint):
+    try:
+        return int(sint)
+    except ValueError:
+        return -1
 
 class Version(object):
     """
     a version class that can facilitate comparisons
     """
 
-    def _toint(self, field):
-        try:
-            return int(field)
-        except ValueError:
-            return field
-
     def __init__(self, vers):
         """
         convert a version string to a Version instance
         """
-        self._vs = vers
-        self.fields = self._vs.split('.')
+        if isinstance(vers, (str, _unicode)):
+            self._vs = vers
+            self.fields = [_2int(v) for v  in self._vs.split('.')]
+        elif isinstance(vers, tuple):
+            self._vs = ".".join([str(v) for v in vers])
+            self.fields = tuple(vers)
+        else:
+            raise TypeError("Input version is not str or tuple: " + str(vers))
 
     def __str__(self):
         return self._vs

--- a/multibag/split.py
+++ b/multibag/split.py
@@ -84,7 +84,7 @@ class SplitPlan(object):
         prescribe the contents of each output multibag.
         """
         if len(self._manifests) == 0:
-            raise StopIteration()
+            return
         
         i = 0
         while i < len(self._manifests):

--- a/tests/multibag/test_amend.py
+++ b/tests/multibag/test_amend.py
@@ -334,6 +334,7 @@ class TestAmender(test.TestCase):
                                    "member-bags.tsv")
         self.assertTrue(not os.path.exists(membagsfile))
 
+        self.amender._init_multibag_info()
         self.amender._init_member_bags()
         self.assertTrue(not os.path.exists(membagsfile))
         self.assertEqual(self.amender._newhead.member_bag_names, ["samplembag"])
@@ -350,6 +351,7 @@ class TestAmender(test.TestCase):
                                    "member-bags.tsv")
         self.assertTrue(not os.path.exists(membagsfile))
 
+        self.amender._init_multibag_info()
         self.amender._init_member_bags()
         self.assertTrue(not os.path.exists(membagsfile))
         self.assertEqual(self.amender._newhead.member_bag_names, ["gooberbag"])
@@ -367,6 +369,7 @@ class TestAmender(test.TestCase):
                                    "member-bags.tsv")
         self.assertTrue(os.path.exists(membagsfile))
 
+        self.amender._init_multibag_info()
         self.amender._init_member_bags()
         self.assertTrue(not os.path.exists(membagsfile))
         self.assertEqual(self.amender._newhead.member_bag_names, ["gooberbag"])
@@ -377,6 +380,7 @@ class TestAmender(test.TestCase):
         self.assertTrue(not os.path.exists(lufile))
         self.assertIsNone(self.amender._newhead.lookup_file("data/trial1.json"))
 
+        self.amender._init_multibag_info()
         self.amender._init_file_lookup()
         self.assertTrue(not os.path.exists(lufile))
         self.assertEqual(self.amender._newhead.lookup_file("data/trial1.json"),
@@ -395,6 +399,7 @@ class TestAmender(test.TestCase):
         self.assertTrue(not os.path.exists(lufile))
         self.assertIsNone(self.amender._newhead.lookup_file("data/trial1.json"))
 
+        self.amender._init_multibag_info()
         self.amender._init_file_lookup()
         self.assertTrue(not os.path.exists(lufile))
         self.assertEqual(self.amender._newhead.lookup_file("data/trial1.json"),
@@ -413,6 +418,7 @@ class TestAmender(test.TestCase):
                               "file-lookup.tsv")
         self.assertTrue(os.path.exists(lufile))
 
+        self.amender._init_multibag_info()
         self.amender._init_file_lookup()
         self.assertTrue(not os.path.exists(lufile))
         self.assertEqual(self.amender._newhead.lookup_file("data/trial1.json"),
@@ -420,8 +426,11 @@ class TestAmender(test.TestCase):
 
     def test_init_multibag_info(self):
         self.assertNotIn('Multibag-Head-Deprecates', self.amender._newhead.info)
+        self.assertNotIn('Multibag-Version', self.amender._newhead.info)
         
         self.amender._init_multibag_info()
+        self.assertEqual(self.amender._newhead.info.get('Multibag-Version'),
+                                                        amend.CURRENT_VERSION)
         self.assertEqual(
             self.amender._newhead.info.get('Multibag-Head-Deprecates'),
             ["1.0"])

--- a/tests/multibag/test_constants.py
+++ b/tests/multibag/test_constants.py
@@ -14,7 +14,11 @@ class TestVersion(test.TestCase):
     def test_ctor(self):
         ver = cnsts.Version("3.3.5.0")
         self.assertEqual(ver._vs, "3.3.5.0")
-        self.assertEqual(ver.fields, ['3','3','5','0'])
+        self.assertEqual(ver.fields, [3, 3, 5, 0])
+
+        ver = cnsts.Version((3, 3, 5, 0))
+        self.assertEqual(ver._vs, "3.3.5.0")
+        self.assertEqual(ver.fields, (3, 3, 5, 0))
 
     def testEQ(self):
         ver = cnsts.Version("3.3.0")


### PR DESCRIPTION
This bug revealed itself when the LoC BagIt library started warning about the deprecated use of `Bag.version`.  This originated from `multibag.HeadBagReadMixin.iter_member_bags()` and revealed that the wrong version was being queried for.  This function should have been using the bag's `profile_version` rather than `version`.  This further revealed that the `amend` module (which creates updates to existing bag aggregations) was failing to ensure that the profile version of the new head bag was being set before it was needed.  Further revealed was a bug comparing/ordering version strings. This PR fixes all of these bugs.

In this fix, it makes it explicit that a new head bag added to an existing aggregation will be compliant with the latest version of the multibag profile; however, a switch provided to `Amender.init_from_amendee()` can allow the profile version of the previous head bag to be applied.  

Given the passage of time and the need to support python 3.7, this PR also provides some changes to support later versions of python:
 * testing 3.3 was dropped from travis testing (this could be added later); 3.7, 3.8, and 3.9 were added
 * updates in the use of iterators were necessary due to changes in Python's handling of `StopIteration`
