### PR TITLE
restore: Implement aggregation recombining

### DIFF
--- a/docs/multibag-profile-spec.md
+++ b/docs/multibag-profile-spec.md
@@ -1,5 +1,7 @@
 # The Multibag BagIt Profile
 
+Version 0.5
+
 __Contents__
 * [Overview](#Overview)
 * [The Multibag Data Structure](#The_Multibag_Data_Structure)
@@ -310,7 +312,7 @@ from the aggregation.
 
 _This section is normative._
 
-It must always be possible, in principle, to combine all of the bags in a Multibag aggregation into a single BagIt-compliant bag (barring storage and compute resource limitations) by following the process detailed in this section.  The `member-bags.tsv` file lists the member bags in an aggregation in the order which they must be combined.  
+It must always be possible, in principle, to combine all of the bags in a Multibag aggregation into a single BagIt-compliant bag (barring storage and compute resource limitations) by following the process detailed in this section.  Other methods that produce the same end result may be used; however, this method defines the end-result.  The `member-bags.tsv` file lists the member bags in an aggregation in the order which they must be combined.  
 
 An application MUST be able to combine a Multibag aggregation into a single bag by following the these steps:
 
@@ -322,7 +324,7 @@ An application MUST be able to combine a Multibag aggregation into a single bag 
    directory structure. In this process, updated versions of files MAY
    overwrite deprecated versions (with the exception of the
    BagIt-specific files, `bagit.txt`, `bag-info.txt`, `fetch.txt` and
-   the manifests, which must be handled separately. 
+   the manifests, which must be handled separately). 
    1. The special BagIt-specific files for the combined bag should be reconstituted according to the following rules:
       <dl>
           <dt> 4.1. <code>bagit.txt</code> </dt>
@@ -340,7 +342,7 @@ An application MUST be able to combine a Multibag aggregation into a single bag 
                Directory</a>), that file should be installed as the
                <code>bag-info.txt</code> file for the aggregated bag.  The
                application may make additional changes to file
-               afterward.  In particular, the application may update
+               later.  In particular, the application may update
                the <code>Payload-Oxum</code> and <code>Bag-Size</code>
                fields to ensure their values are correct for the 
                aggregated bag.</p>
@@ -359,7 +361,7 @@ An application MUST be able to combine a Multibag aggregation into a single bag 
                       All remaining values associated with a given
                       field name then over-ride all previous values with the 
                       same name.  Tag data with names not previously 
-                      encountered in this process are added to aggregated 
+                      encountered in this process are added to the aggregated 
                       tag data.  </li>
                  <li> After the data from the last bag (the Head Bag)
                       has been merged, all tag data from the excepted list 
@@ -407,8 +409,12 @@ An application MUST be able to combine a Multibag aggregation into a single bag 
           <dd> A manifest file for the aggregated bag, for each
                algorithm represented, must be the union of the same
                manifest files (type and algorithm) of all of the
-               member bags.   </dd>
+               member bags but excluding the files listed in the
+               <code>deleted.txt</code> file.   </dd>
       </dl>
+   1. The `multibag` tag directory should be removed.
+   1. If the aggregated bag is to be Bagit-compliant, the `bag-info.txt` file should be updated to reset
+      the `Payload-Oxum` and `Bag-Size` tags to values applicable to the aggregated bag.  
       
 Other BagIt profiles may specify rules for reconstituting other tag files from versions in the member bags.  In the absence of such rules, applications should assume assume that versions in the member bags listed later should replace those listed earlier. 
 
@@ -446,6 +452,11 @@ Multibag component was spun off to create its verison 0.2.
    * The rules for setting the contents of the special BagIt files
      (`bagit.txt`, `bag-info.txt`, `fetch.txt`, and the manifests) are
      spelled out.
+
+## Since 0.4
+
+   * The algorithm for "Combining Multibags Into a Single Bag" was
+     adjusted to account for the presence of a `deleted.txt` file.  
 
 ## To do
 

--- a/multibag/access/extended.py
+++ b/multibag/access/extended.py
@@ -423,6 +423,78 @@ class _ExtendedReadWritableMixin(ExtendedReadMixin):
             
             yield dir, subdirs, files
 
+    def calc_oxum(self):
+        """
+        calculate and return the Bagit-defined Payload-Oxum as a 2-tuple for 
+        the bag in its current state
+        :return:  a 2-tuple where the first element is the total number of 
+                  file bytes and the second element is the total number of 
+                  files.  
+        """
+        nf = 0
+        sz = 0
+        for root, dirs, files in self.walk("data"):
+            for f in files:
+                nf += 1
+                sz += self.sizeof("/".join([root, f]))
+        return (sz, nf)
+
+    def update_oxum(self):
+        """
+        calculate and save the current Payload_Oxum to the in-memory tag metadata (self.info).
+        The save() method should be called to commit this value into the bag.
+        """
+        oxum = self.calc_oxum()
+        self.info['Payload-Oxum'] = "%s.%s" % oxum
+        return oxum
+
+    def calc_bag_size(self):
+        """
+        estimate the current size of the bag in bytes.  The save() function should be called 
+        before this method for a more accurate estimate.
+        """
+        sz = 0
+        for root, dirs, files in self.walk():
+            for f in files + dirs:
+                sz += self.sizeof(os.path.join(root, f))
+
+        # fine adjustments
+        if 'Bag-Size' in self.info:
+            sz -= len(self.info['Bag-Size'])
+            sz += len(self._format_bytes(sz))
+
+        return sz
+
+    def update_bag_size(self):
+        """
+        estimate and save the current size of the bag to the in-memory tag metadata (self.info)
+        The save() method should be called before this method to get a more accurate estimate, 
+        and it should be called after this to commit this value into the bag.
+        """
+        sz = self.calc_bag_size()
+        self.info['Bag-Size'] = self._format_bytes(sz)
+        return sz
+
+    def _format_bytes(self, nbytes):
+        prefs = ["", "k", "M", "G", "T"]
+        ordr = 0
+        while nbytes >= 1000.0 and ordr < 4:
+            nbytes /= 1000.0
+            ordr += 1
+        pref = prefs[ordr]
+        ordr = 0
+        while nbytes >= 10.0:
+            nbytes /= 10.0
+            ordr += 1
+        nbytes = "{0:5f}".format(round(nbytes, 3) * 10**ordr)
+        if '.' in nbytes:
+            nbytes = re.sub(r"0+$", "", nbytes)
+        if nbytes.endswith('.'):
+            nbytes = nbytes[:-1]    
+        return "{0} {1}B".format(nbytes, pref)
+
+        
+
 class ExtendedReadWritableBag(Bag, _ExtendedReadWritableMixin):
     """
     A Bag with an extended interface.

--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -734,12 +734,6 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
             nbytes = nbytes[:-1]    
         return "{0} {1}B".format(nbytes, pref)
 
-    
-
-    
-                                
-
-    
 
 class ReadOnlyHeadBag(ExtendedReadOnlyBag, HeadBagReadMixin):
     """
@@ -798,6 +792,8 @@ class HeadBag(ExtendedReadWritableBag, HeadBagUpdateMixin):
 
         :param str bagpath:  a filepath to the bag's root directory.  
         """
+        if not os.path.isdir(bagpath):
+            raise ValueError("HeadBag(): bagpath must point to a directory (for write access)")
         super(HeadBag, self).__init__(bagpath)
         HeadBagReadMixin.__init__(self)
         HeadBagUpdateMixin.__init__(self)

--- a/multibag/restore.py
+++ b/multibag/restore.py
@@ -1,0 +1,343 @@
+"""
+functions for restoring a bag from its multibag components.
+"""
+import os, sys, re, shutil, io, time, errno
+from collections import OrderedDict
+
+from .constants import CURRENT_VERSION as MBAG_VERSION
+from .access.bagit import Bag, ReadOnlyBag
+from .access.multibag import (is_headbag, as_headbag, open_headbag, MissingMultibagFileError,
+                              HeadBag, ReadOnlyHeadBag, MultibagError)
+from .access.extended import as_extended, ExtendedReadMixin as ProgenitorMixin
+from .access.bagit import _ext_fs_lookup, open_bag, Bag
+
+class _FileNotFoundError(OSError):
+    def __init__(self, message):
+        super(_FileNotFoundError, self).__init__(message)
+        self.errno = errno.ENOENT
+
+if sys.version_info[0] > 2:
+    _unicode = str
+else:
+    _unicode = unicode
+    FileNotFoundError = _FileNotFoundError 
+
+serialized_extensions = set(_ext_fs_lookup.keys())
+
+class BagRestorer(object):
+    """
+    A class for managing the restoration of a complete bag from its multibag components.  
+    The :py:meth:`restore` method can be used to restore the full bag in one shot, 
+    following the multibag metadata from a head bag; however, the other method allow more 
+    fine-control over the restoration.
+    """
+
+    def __init__(self, headbag, destbag=None, compdir=None, fetcher=None):
+        """
+        create the restorer.
+        :param headbag:     the head bag for the bag to restore.  If the input is a 
+                            ReadOnlyHeadBag, the destbag parameter must be specified.
+                            :type headbag: str, HeadBag, or ReadOnlyHeadBag
+        :param destbag:     the destination for the restore bag.  Normally, this would 
+                            not exist yet at construction time, but providing an existing 
+                            bag will cause that bag to be filled out to create the complete 
+                            bag.  Not providing this will cause the headbag to be updated
+                            in place.  
+                            :type destbag: str or Bag
+        :param compdir:     a directory where component multibags can be found (or cached to
+                            when fetcher is set)
+                            :type compdir: str
+        :param fetcher:     a function that can fetch a remote multibag and which must two 
+                            arguments.  The first argument is the name of the desired 
+                            component multibag, as given in the member-bags.tsv file.  The 
+                            second is the destination directory where the bag should be 
+                            cached; this will be set to the value of compdir, if set.  The 
+                            function must return the path to the cached bag.  
+        """
+        if isinstance(headbag, (str, _unicode)):
+            if not os.path.exists(headbag):
+                raise FileNotFoundError("Missing head bag: "+headbag)
+            if not is_headbag(headbag):
+                raise MultibagError("Not a head bag")
+            headbag = open_headbag(headbag)
+
+        self._head = headbag
+        self._inplace = False
+
+        if not destbag:
+            destbag = self._head
+            self._inplace = True
+
+        if isinstance(destbag, Bag):
+            destbag = destbag.path
+        destbag = os.path.abspath(destbag)
+        parent = os.path.dirname(destbag)
+        if not os.path.isdir(parent):
+            raise FileNotFoundError("Parent of destination bag directory does not exist as a directory")
+        self._destdir = destbag
+
+        if not self._inplace:
+            self._inplace = destbag == os.path.abspath(self._head.path)
+
+        self._fetcher = fetcher
+        if not compdir:
+            if self._fetcher:
+                # set a default cached directory inside the target destination bag
+                compdir = os.path.join(self._destdir, "multibag", "_membercache")
+            else:
+                compdir = os.path.dirname(os.path.abspath(self._head.path))
+        self._cachedir = compdir
+
+    @property
+    def destination_bagdir(self):
+        return self._destdir
+
+    @property
+    def head_bag(self):
+        return self._head
+
+    @property
+    def cache_dir(self):
+        return self._cachedir
+
+    def _create_dest_bag(self):
+        if not os.path.exists(self._destdir):
+            os.mkdir(self._destdir)
+        if not os.path.exists(self._cachedir) and self._cachedir.startswith(self._destdir):
+            # if the cache dir is located inside the destination bag, create that dir, too
+            os.makedirs(self._cachedir)
+
+    def find_member_bag(self, bagname):
+        """
+        Look for the member bag in the cache directory and return its path.  The member bag 
+        may be in a serialized form.  None is returned if no usable form of the bag can be found
+        """
+        # does the bag exist in the cache as a directory?
+        bagdir = os.path.join(self._cachedir, bagname)
+        if os.path.isdir(bagdir):
+            return bagdir
+
+        # look for a supported serialized version of the bag in the cache
+        sers = [f for f in [bagdir+e for e in serialized_extensions] if os.path.isfile(f)]
+        if sers:
+            return sers[0]
+        return None
+
+    def _fetch_member_bag(self, bagname):
+        if not self._fetcher:
+            return None
+        if not os.path.exists(self._cachedir) and self._cachedir.startswith(self._destdir):
+            self._create_dest_bag()
+        return self._fetcher(bagname, self._cachedir)
+
+    def get_member_bag(self, bagname):
+        """
+        return the path to a readable bag matching the given bagname.  
+        """
+        out = self.find_member_bag(bagname)
+        if not out:
+            out = self._fetch_member_bag(bagname)
+        return out
+
+    def restore_member(self, bagname, skip=None, fetch=None, overwrite=False):
+        """
+        copy files from the specified member bag into the destination bag according to the rules 
+        for multibag restoration.  In particular, only files from the member bag not present in the
+        destination bag will be copied (unless overwrite=True).  
+        :param str bagname:  the name of the bag to restore into the destination bag.  This name is 
+                             expected to be of a form as given in the member-bags.tsv file.
+        :param skip:         a list of paths in that bag to not restore; this is intended to hold 
+                             a list of files that have been marked as deleted from an aggregation.
+        """
+        src = self.get_member_bag(bagname)
+        if not src:
+            raise FileNotFoundError("Member bag not found: "+bagname)
+        self._restore_from(src, skip, overwrite)
+
+        if fetch is not None:
+            membag = open_bag(src)
+            if membag.isfile("fetch.txt"):
+                with membag.open_text_file("fetch.txt") as fd:
+                    for line in fd:
+                        filen = line.strip().rsplit(None, 1)[0]
+                        if filen not in fetch:
+                            fetch[filen] = line
+
+    def _restore_from(self, srcbag, skip=None, overwrite=False):
+        if os.path.abspath(srcbag) == self._destdir:
+            # srcbag is destination bag
+            return
+        if not os.path.exists(self._destdir):
+            self._create_dest_bag()
+        if skip is None:
+            skip = []
+        updated = []
+
+        srcbag = as_extended(open_bag(srcbag))
+        for root, dirs, files in srcbag.walk():
+            if root in skip or len([f for f in skip if root.startswith(f+'/')]) > 0:
+                # if this root directory has been marked as deleted, skip it
+                continue
+
+            rmtime = os.stat(os.path.join(self._destdir, root)).st_mtime
+
+            for f in files:
+                if os.path.join(root, f) in skip:
+                    continue
+                destf = os.path.join(self._destdir, root, f)
+                if overwrite and os.path.exists(destf):
+                    os.remove(destf)
+                if not os.path.exists(destf):
+                    srcpath = "/".join([root, f])
+                    srcbag.replicate(srcpath, self._destdir)
+                    updated.append(srcpath)
+
+                    # try to copy the modification time
+                    times = srcbag.timesfor(srcpath)
+                    if times:
+                        os.utime(destf, (time.time(), times.mtime))
+
+            for f in dirs:
+                if os.path.join(root, f) in skip:
+                    continue
+                destf = os.path.join(self._destdir, root, f)
+                if not os.path.exists(destf):
+                    os.makedirs(destf)
+
+                    # try to copy the modification time
+                    srcpath = "/".join([root, f])
+                    times = srcbag.timesfor(srcpath)
+                    if times:
+                        os.utime(destf, (time.time(), times.mtime))
+
+            if rmtime:
+                os.utime(os.path.join(self._destdir, root), (time.time(), rmtime))
+
+        if updated:
+            self._update_manifests(srcbag, updated)
+
+    def _update_manifests(self, srcbag, updated):
+        destbag = open_bag(self._destdir)
+
+        updated_by_alg = OrderedDict()
+        for path in updated:
+            if path in srcbag.entries:
+                for alg in srcbag.entries[path]:
+                    if alg not in updated_by_alg:
+                        updated_by_alg[alg] = OrderedDict()
+                    updated_by_alg[alg][path] = srcbag.entries[path][alg]
+                
+        for path in destbag.entries:
+            for alg in updated_by_alg:
+                if path not in updated_by_alg[alg]:
+                    updated_by_alg[alg][path] = destbag.entries[path][alg]
+
+        for alg in updated_by_alg:
+            files = [f for f in updated_by_alg[alg].keys() if f.startswith("data/")]
+            if len(files) > 0:
+                with open(os.path.join(self._destdir, "manifest-%s.txt" % alg), 'w') as fd:
+                    for f in files:
+                        fd.write("%s %s\n" % (updated_by_alg[alg][f], f))
+
+            files = [f for f in updated_by_alg[alg].keys() if not f.startswith("data/")]
+            if len(files) > 0:
+                with open(os.path.join(self._destdir, "tagmanifest-%s.txt" % alg), 'w') as fd:
+                    for f in files:
+                        fd.write("%s %s\n" % (updated_by_alg[alg][f], f))
+
+        
+    def restore_fetch(self):
+        """
+        restore the fetch file to the output bag.  
+        """
+        if not os.path.exists(self._destdir):
+            self._create_dest_bag()
+
+        members = list(self._head.member_bags())
+        fetch = OrderedDict()
+        for member in members:
+            src = self.get_member_bag(member.name)
+            bag = open_bag(src)
+            if bag.isfile("fetch.txt"):
+                with bag.open_text_file("fetch.txt") as fd:
+                    for line in fd:
+                        parts = line.strip().rsplit(None, 1)
+                        if len(parts) > 1 and parts[1]:
+                            fetch[parts[1]] = line
+        if fetch:
+            with open(os.path.join(self._destdir, "fetch.txt"), 'w') as fd:
+                for f in fetch:
+                    fd.write(fetch[f])
+
+    def restore(self, update_sizes=True, remove_multibag_tags=True):
+        """
+        properly recombine all of member bags in the multibag aggregation specified by the head bag
+        into the destination bag. 
+        """
+        skip = self._head.deleted_paths()
+        members = list(reversed(self._head.member_bags()))
+        if not os.path.exists(self._destdir):
+            self._create_dest_bag()
+
+        if self._head.isfile("multibag/aggregation-info.txt"):
+            with self._head.open_text_file("multibag/aggregation-info.txt") as fd:
+                content = fd.read()
+            with open(os.path.join(self._destdir, "bag-info.txt"), 'w') as fd:
+                fd.write(content)
+                    
+        if not self._inplace:
+            self._restore_from(self._head.path, skip)
+        if members and members[0] == self._head.name:
+            members.pop(0)
+
+        for member in members:
+            self.restore_member(member.name, skip)
+
+        # now build the fetch.txt file if any found
+        self.restore_fetch()
+
+        restoredbag = as_extended(Bag(self._destdir))
+        if remove_multibag_tags:
+            shutil.rmtree(os.path.join(self._destdir, "multibag"))
+            mbkeys = "Multibag-Version Multibag-Reference Multibag-Tag-Directory".split()
+            mbkeys += "Multibag-Head-Version Multibag-Head-Deprecates".split()
+            mbkeys = [k for k in mbkeys if k in restoredbag.info]
+            for key in mbkeys:
+                del restoredbag.info[key]
+            restoredbag.save()
+            
+        if update_sizes:
+            restoredbag.update_oxum()
+            restoredbag.save()
+            restoredbag.update_bag_size()
+            restoredbag.save()
+            
+
+def restore_bag(headbag, destbag=None, compdir=None, fetcher=None):
+    """
+    restore a multibag aggregation to a single bag
+    :param headbag:     the head bag for the bag to restore.  If the input is a 
+                        ReadOnlyHeadBag, the destbag parameter must be specified.
+                        :type headbag: str, HeadBag, or ReadOnlyHeadBag
+    :param destbag:     the destination for the restore bag.  Normally, this would 
+                        not exist yet at construction time, but providing an existing 
+                        bag will cause that bag to be filled out to create the complete 
+                        bag.  Not providing this will cause the headbag to be updated
+                        in place.  
+                        :type destbag: str or Bag
+    :param compdir:     a directory where component multibags can be found (or cached to
+                        when fetcher is set)
+                        :type compdir: str
+    :param fetcher:     a function that can fetch a remote multibag and which must two 
+                        arguments.  The first argument is the name of the desired 
+                        component multibag, as given in the member-bags.tsv file.  The 
+                        second is the destination directory where the bag should be 
+                        cached; this will be set to the value of compdir, if set.  The 
+                        function must return the path to the cached bag.  
+    :return:  the restored bag
+    """
+    r = BagRestorer(headbag, destbag, compdir, fetcher)
+    r.restore()
+    return ExtendedReadWritableBag(r.destination_bagdir)
+
+

--- a/tests/multibag/__init__.py
+++ b/tests/multibag/__init__.py
@@ -1,7 +1,7 @@
 from unittest import TestLoader, TestSuite
 
 def additional_tests():
-    from . import test_constants, test_split, test_amend
+    from . import test_constants, test_split, test_amend, test_restore
 
     suites = [TestLoader().loadTestsFromModule(m[1])
                      for m in globals().items() if m[0].startswith("test_")]

--- a/tests/multibag/access/test_extended.py
+++ b/tests/multibag/access/test_extended.py
@@ -242,7 +242,38 @@ class TestExtendedReadWritableBag(test.TestCase):
 
     def test_is_head_multibag(self):
         self.assertTrue(self.bag.is_head_multibag())
+
+    def test_calc_oxum(self):
+        oxum = self.bag.calc_oxum()
+        self.assertTrue(isinstance(oxum, tuple))
+        self.assertEqual(len(oxum), 2)
+        self.assertTrue(all([isinstance(x, int) for x in oxum]))
+        self.assertEqual(oxum[1], 3)
+        self.assertEqual(oxum[0], 208)
     
+    def test_update_oxum(self):
+        del self.bag.info['Payload-Oxum']
+
+        oxum = self.bag.update_oxum()
+        self.assertTrue(isinstance(oxum, tuple))
+        self.assertEqual(len(oxum), 2)
+        self.assertTrue(all([isinstance(x, int) for x in oxum]))
+        self.assertEqual(oxum[1], 3)
+        self.assertEqual(oxum[0], 208)
+    
+        self.assertEqual(self.bag.info['Payload-Oxum'], "208.3")
+
+    def test_calc_bag_size(self):
+        size = self.bag.calc_bag_size()
+        self.assertTrue(isinstance(size, int))
+        self.assertEqual(size, 20832)
+
+    def test_update_bag_size(self):
+        size = self.bag.update_bag_size()
+        self.assertTrue(isinstance(size, int))
+        self.assertEqual(size, 20832)
+
+        self.assertEqual(self.bag.info['Bag-Size'], "20.83 kB")
 
 class TestExtendReadOnlyBag(test.TestCase):
 

--- a/tests/multibag/access/test_extended.py
+++ b/tests/multibag/access/test_extended.py
@@ -67,6 +67,22 @@ class TestExtendedReadWritableBag(test.TestCase):
         with self.assertRaises(OSError):
             self.bag.sizeof("data/goober")
 
+    def test_timesfor(self):
+        times = self.bag.timesfor("data/trial1.json")
+        self.assertIsNotNone(times)
+        self.assertGreater(times.ctime, 0)
+        self.assertGreater(times.mtime, 0)
+        self.assertGreater(times.atime, 0)
+
+        times = self.bag.timesfor("data")
+        self.assertIsNotNone(times)
+        self.assertGreater(times.ctime, 0)
+        self.assertGreater(times.mtime, 0)
+        self.assertGreater(times.atime, 0)
+
+        with self.assertRaises(OSError):
+            self.bag.timesfor("data/goober")
+
     def test_bag(self):
         # test that self.bag behaves like a bagit.Bag
         self.assertEqual(self.bag.algs, ["sha256"])
@@ -273,6 +289,22 @@ class TestExtendReadOnlyBag(test.TestCase):
         self.assertEqual(self.bag.sizeof("data"), 0)
         with self.assertRaises(OSError):
             self.bag.sizeof("data/goober")
+
+    def test_timesfor(self):
+        times = self.bag.timesfor("data/trial1.json")
+        self.assertIsNotNone(times)
+        self.assertIsNone(times.ctime)
+        self.assertIsNone(times.atime)
+        self.assertGreater(times.mtime, 0)
+
+        times = self.bag.timesfor("data")
+        self.assertIsNotNone(times)
+        self.assertIsNone(times.ctime)
+        self.assertIsNone(times.atime)
+        self.assertGreater(times.mtime, 0)
+
+        with self.assertRaises(OSError):
+            self.bag.timesfor("data/goober")
 
     def test_bag(self):
         # test that self.bag behaves like a bagit.Bag

--- a/tests/multibag/test_restore.py
+++ b/tests/multibag/test_restore.py
@@ -295,7 +295,10 @@ class TestRestorer(test.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial2.json")))
         self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial3", "trial3a.json")))
         self.assertTrue(not os.path.isfile(os.path.join(restored,"data","trial4.json")))
-        
+
+        restoredbag = open_bag(self.v2)
+        restoredbag.validate()
+
         rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
         self.assertTrue(os.path.exists(self.v2))
         self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial1.json")))
@@ -312,6 +315,9 @@ class TestRestorer(test.TestCase):
         with open(os.path.join(self.v2,"data","trial2.json")) as fd:
             content = fd.read()
         self.assertEqual('"Goober!"\n', content)
+
+        restoredbag = open_bag(self.v2)
+        restoredbag.validate()
         
 
 if __name__ == '__main__':

--- a/tests/multibag/test_restore.py
+++ b/tests/multibag/test_restore.py
@@ -1,0 +1,319 @@
+# encoding: utf-8
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import os, pdb, logging
+import tempfile, shutil
+import unittest as test
+
+from fs import open_fs
+
+import bagit
+import multibag.restore as restore
+import multibag.split as split
+import multibag.amend as amend
+from multibag.access.bagit import Bag, ReadOnlyBag, Path, open_bag
+
+datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                       "access", "data")
+
+def ishardlink(path):
+    return os.stat(path).st_nlink > 1
+
+class TestRestorer(test.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.bagdir = os.path.join(self.tempdir, "samplebag")
+        shutil.copytree(os.path.join(datadir, "samplembag"), self.bagdir)
+        shutil.rmtree(os.path.join(self.bagdir, "multibag"))
+        
+        self.spltr = split.NeighborlySplitter(500)
+        self.spltr.split(self.bagdir, self.tempdir)
+
+        mbags = [d for d in os.listdir(self.tempdir) if d.endswith(".mbag")]
+        self.assertIn("samplebag_1.mbag", mbags)
+        self.assertIn("samplebag_2.mbag", mbags)
+        self.assertIn("samplebag_3.mbag", mbags)
+        self.assertEqual(len(mbags), 3)
+
+        amenddir = os.path.join(self.tempdir, "amendment")
+        os.mkdir(amenddir)
+        with open(os.path.join(amenddir, "trial2.json"), 'w') as fd:
+            fd.write('"Goober!"\n')
+        with open(os.path.join(amenddir, "trial4.json"), 'w') as fd:
+            fd.write('"Gomer!"\n')
+        bagit.make_bag(amenddir, checksum=['sha256'])
+        amend.amend_bag_with(os.path.join(self.tempdir, "samplebag_3.mbag"),
+                             amenddir, "2.0")
+        with open(os.path.join(amenddir, "multibag", "deleted.txt"), 'w') as fd:
+            fd.write("data/trial1.json\n")
+
+        self.v1 = os.path.join(self.tempdir, "samplebag_3.mbag")
+        self.v2 = os.path.join(self.tempdir, "amendment")
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_ctor(self):
+        dest = os.path.join(self.tempdir, "restored")
+        rstr = restore.BagRestorer(self.v1, dest, self.tempdir)
+        self.assertEqual(rstr.destination_bagdir, os.path.join(self.tempdir, "restored"))
+        self.assertEqual(rstr.head_bag.path, self.v1)
+        self.assertEqual(rstr.cache_dir, self.tempdir)
+        self.assertFalse(rstr._inplace)
+
+        rstr = restore.BagRestorer(self.v1, compdir=self.tempdir)
+        self.assertEqual(rstr.destination_bagdir, self.v1)
+        self.assertEqual(rstr.head_bag.path, self.v1)
+        self.assertEqual(rstr.cache_dir, self.tempdir)
+        self.assertTrue(rstr._inplace)
+
+        rstr = restore.BagRestorer(self.v1, fetcher=lambda a,b: os.path.join(b,a))
+        self.assertEqual(rstr.destination_bagdir, self.v1)
+        self.assertEqual(rstr.head_bag.path, self.v1)
+        self.assertEqual(rstr.cache_dir, os.path.join(self.v1, "multibag", "_membercache"))
+
+        with self.assertRaises(OSError):
+            rstr = restore.BagRestorer("goober")
+        with self.assertRaises(restore.MultibagError):
+            rstr = restore.BagRestorer(os.path.join(self.tempdir, "samplebag_2.mbag"))
+            
+    def test_create_dest_bag(self):
+        dest = os.path.join(self.tempdir, "restored")
+        rstr = restore.BagRestorer(self.v1, dest, self.tempdir)
+        self.assertEqual(rstr.destination_bagdir, os.path.join(self.tempdir, "restored"))
+        self.assertEqual(rstr.head_bag.path, self.v1)
+        self.assertEqual(rstr.cache_dir, self.tempdir)
+        self.assertFalse(rstr._inplace)
+        self.assertFalse(os.path.exists(rstr.destination_bagdir))
+
+        rstr._create_dest_bag()
+        self.assertTrue(os.path.exists(rstr.destination_bagdir))
+        self.assertFalse(os.path.exists(os.path.join(rstr.destination_bagdir, "multibag")))
+
+        rstr = restore.BagRestorer(self.v1, fetcher=lambda a,b: os.path.join(b,a))
+        self.assertEqual(rstr.destination_bagdir, self.v1)
+        self.assertEqual(rstr.head_bag.path, self.v1)
+        self.assertEqual(rstr.cache_dir, os.path.join(self.v1, "multibag", "_membercache"))
+        self.assertTrue(os.path.exists(rstr.destination_bagdir))
+        self.assertFalse(os.path.exists(os.path.join(rstr.destination_bagdir, "multibag", "_membercache")))
+
+        rstr._create_dest_bag()
+        self.assertTrue(os.path.exists(rstr.destination_bagdir))
+        self.assertTrue(os.path.exists(os.path.join(rstr.destination_bagdir, "multibag", "_membercache")))
+        
+    def test_find_member_bag(self):
+        os.system("cd %s; zip -qr samplebag_3.mbag.zip samplebag_3.mbag" % self.tempdir)
+        shutil.rmtree(os.path.join(self.tempdir, "samplebag_3.mbag"))
+
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
+        self.assertEqual(rstr.find_member_bag("samplebag_1.mbag"),
+                         os.path.join(self.tempdir, "samplebag_1.mbag"))
+        self.assertEqual(rstr.find_member_bag("samplebag_3.mbag"),
+                         os.path.join(self.tempdir, "samplebag_3.mbag.zip"))
+        
+    def test_fetch_member_bag(self):
+        os.system("cd %s; zip -qr samplebag_3.mbag.zip samplebag_3.mbag" % self.tempdir)
+        self.assertTrue(os.path.isfile(os.path.join(self.tempdir, "samplebag_3.mbag.zip")))
+        shutil.rmtree(os.path.join(self.tempdir, "samplebag_3.mbag"))
+        self.assertTrue(not os.path.isdir(os.path.join(self.tempdir, "samplebag_3.mbag")))
+
+        def ftchr(bag, todir):
+            zipd = os.path.join(self.tempdir, bag+".zip")
+            if os.path.exists(zipd):
+                os.system("cd %s; unzip -q %s" % (todir, zipd))
+                return os.path.join(todir, os.path.splitext(os.path.basename(zipd))[0])
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir, fetcher=ftchr)
+
+        found = rstr._fetch_member_bag("samplebag_3.mbag")
+        self.assertEqual(found, os.path.join(self.tempdir, "samplebag_3.mbag"))
+        self.assertTrue(os.path.isdir(os.path.join(self.tempdir, "samplebag_3.mbag")))
+
+    def test_get_member_bag(self):
+        lts = os.path.join(self.tempdir, "remote")
+        os.mkdir(lts)
+        os.system("cd %s; zip -qr %s/samplebag_3.mbag.zip samplebag_3.mbag" % (self.tempdir, lts))
+        self.assertTrue(os.path.isfile(os.path.join(lts, "samplebag_3.mbag.zip")))
+        shutil.rmtree(os.path.join(self.tempdir, "samplebag_3.mbag"))
+        self.assertTrue(not os.path.isdir(os.path.join(self.tempdir, "samplebag_3.mbag")))
+
+        def ftchr(bag, todir):
+            zipd = os.path.join(self.tempdir, "remote", bag+".zip")
+            if os.path.exists(zipd):
+                os.system("cd %s; unzip -q %s" % (todir, zipd))
+                return os.path.join(todir, os.path.splitext(os.path.basename(zipd))[0])
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir, fetcher=ftchr)
+
+        found = rstr.get_member_bag("samplebag_1.mbag")
+        self.assertEqual(found, os.path.join(self.tempdir, "samplebag_1.mbag"))
+        found = rstr.get_member_bag("samplebag_3.mbag")
+        self.assertEqual(found, os.path.join(self.tempdir, "samplebag_3.mbag"))
+        self.assertTrue(os.path.isdir(os.path.join(self.tempdir, "samplebag_3.mbag")))
+
+    def test_restore_member(self):
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial3")))
+
+        with self.assertRaises(OSError):
+            rstr.restore_member("sample_3.mbag")
+            
+        rstr.restore_member("samplebag_3.mbag")
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial3")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial3", "trial3a.json")))
+
+        with open(os.path.join(self.v2,"data","trial2.json")) as fd:
+            content = fd.read()
+        self.assertEqual('"Goober!"\n', content)
+
+    def test_restore_member_overwrite(self):
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial3")))
+
+        rstr.restore_member("samplebag_3.mbag", overwrite=True)
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial3")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial3", "trial3a.json")))
+
+        with open(os.path.join(self.v2,"data","trial2.json")) as fd:
+            content = fd.read()
+        self.assertNotEqual('"Goober!"\n', content)
+        self.assertTrue(content.startswith('{'))
+        
+    def test_restore_member_from_zip(self):
+        os.system("cd %s; zip -qr samplebag_3.mbag.zip samplebag_3.mbag" % self.tempdir)
+        shutil.rmtree(os.path.join(self.tempdir, "samplebag_3.mbag"))
+
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial3")))
+
+        with self.assertRaises(OSError):
+            rstr.restore_member("sample_3.mbag")
+            
+        rstr.restore_member("samplebag_3.mbag")
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial3")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial3", "trial3a.json")))
+
+        with open(os.path.join(self.v2,"data","trial2.json")) as fd:
+            content = fd.read()
+        self.assertEqual('"Goober!"\n', content)
+
+    def test_restore_fetch(self):
+        with open(os.path.join(self.tempdir, "samplebag_1.mbag", "fetch.txt"), 'w') as fd:
+            fd.write("https://example.com/u1 5 u1\n")
+            fd.write("https://example.com/u2 5 u2\n")
+        with open(os.path.join(self.tempdir, "samplebag_3.mbag", "fetch.txt"), 'w') as fd:
+            fd.write("https://example.com/u1.r 5 u1\n")
+            fd.write("https://example.com/u3 5 u3\n")
+            fd.write("https://example.com/u4 5 u4\n")
+        with open(os.path.join(self.tempdir, "amendment", "fetch.txt"), 'w') as fd:
+            fd.write("https://example.com/u1.r2 5 u1\n")
+            fd.write("https://example.com/u3.r 5 u3\n")
+            fd.write("https://example.com/u5 5 u5\n")
+        
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial3")))
+
+        rstr.restore_fetch()
+        self.assertTrue(os.path.isfile(os.path.join(rstr._destdir, "fetch.txt")))
+        with open(os.path.join(rstr._destdir, "fetch.txt")) as fd:
+            lines = fd.readlines()
+        self.assertEqual(len(lines), 5)
+        self.assertEqual(lines[0], "https://example.com/u1.r2 5 u1\n")
+        self.assertEqual(lines[1], "https://example.com/u2 5 u2\n")
+        self.assertEqual(lines[2], "https://example.com/u3.r 5 u3\n")
+        self.assertEqual(lines[3], "https://example.com/u4 5 u4\n")
+        self.assertEqual(lines[4], "https://example.com/u5 5 u5\n")
+
+        rstr = restore.BagRestorer(self.v1, compdir=self.tempdir)
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial3")))
+
+        rstr.restore_fetch()
+        self.assertTrue(os.path.isfile(os.path.join(rstr._destdir, "fetch.txt")))
+        with open(os.path.join(rstr._destdir, "fetch.txt")) as fd:
+            lines = fd.readlines()
+        self.assertEqual(len(lines), 4)
+        self.assertEqual(lines[0], "https://example.com/u1.r 5 u1\n")
+        self.assertEqual(lines[1], "https://example.com/u2 5 u2\n")
+        self.assertEqual(lines[2], "https://example.com/u3 5 u3\n")
+        self.assertEqual(lines[3], "https://example.com/u4 5 u4\n")
+
+    def test_restore(self):
+        restored = os.path.join(self.tempdir, "restored")
+        rstr = restore.BagRestorer(self.v1, restored, compdir=self.tempdir)
+        self.assertTrue(not os.path.exists(restored))
+
+        rstr.restore()
+        self.assertTrue(os.path.isdir(restored))
+        self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial1.json")))
+        self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial2.json")))
+        self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial3", "trial3a.json")))
+        self.assertTrue(not os.path.isfile(os.path.join(restored,"data","trial4.json")))
+
+        restoredbag = open_bag(restored)
+        restoredbag.validate()
+        
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
+        self.assertTrue(os.path.exists(self.v2))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial1.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial4.json")))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial3")))
+        
+        rstr.restore()
+        self.assertTrue(os.path.isdir(self.v2))
+        self.assertTrue(os.path.isfile(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.v2,"data","trial3", "trial3a.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.v2,"data","trial4.json")))
+        self.assertTrue(not os.path.isfile(os.path.join(self.v2,"data","trial1.json")))
+        with open(os.path.join(self.v2,"data","trial2.json")) as fd:
+            content = fd.read()
+        self.assertEqual('"Goober!"\n', content)
+
+        restoredbag = open_bag(self.v2)
+        restoredbag.validate()
+        
+    def test_restore_zipd(self):
+        os.system("cd %s; zip -qr samplebag_3.mbag.zip samplebag_3.mbag" % self.tempdir)
+        shutil.rmtree(os.path.join(self.tempdir, "samplebag_3.mbag"))
+
+        restored = os.path.join(self.tempdir, "restored")
+        rstr = restore.BagRestorer(self.v1+".zip", restored, compdir=self.tempdir)
+        self.assertTrue(not os.path.exists(restored))
+
+        rstr.restore()
+        self.assertTrue(os.path.isdir(restored))
+        self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial1.json")))
+        self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial2.json")))
+        self.assertTrue(os.path.isfile(os.path.join(restored,"data","trial3", "trial3a.json")))
+        self.assertTrue(not os.path.isfile(os.path.join(restored,"data","trial4.json")))
+        
+        rstr = restore.BagRestorer(self.v2, compdir=self.tempdir)
+        self.assertTrue(os.path.exists(self.v2))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial1.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.v2,"data","trial4.json")))
+        self.assertTrue(not os.path.exists(os.path.join(self.v2,"data","trial3")))
+        
+        rstr.restore()
+        self.assertTrue(os.path.isdir(self.v2))
+        self.assertTrue(os.path.isfile(os.path.join(self.v2,"data","trial2.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.v2,"data","trial3", "trial3a.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.v2,"data","trial4.json")))
+        self.assertTrue(not os.path.isfile(os.path.join(self.v2,"data","trial1.json")))
+        with open(os.path.join(self.v2,"data","trial2.json")) as fd:
+            content = fd.read()
+        self.assertEqual('"Goober!"\n', content)
+        
+
+if __name__ == '__main__':
+    test.main()
+        


### PR DESCRIPTION
This PR adds the `multibag.restore` module that implements the profile's algorithm for recombining a multibag aggregation into a single legal bag.  Some new functions were added to the (extended) Bag interface to aid in this goal.