### PR TITLE
Unicode Support

### DIFF
--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -611,6 +611,11 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
                                'file-lookup.tsv')
         with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for item in self._filelu.items():
+                item = list(item)
+                if isinstance(item[0], str):
+                    item[0] = item[0].decode(DEF_ENC)
+                if isinstance(item[1], str):
+                    item[1] = item[1].decode(DEF_ENC)
                 fd.write(u"{0}\t{1}\n".format(item[0], item[1]))
 
     def clear_file_lookup(self):

--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -22,6 +22,8 @@ _about_mbag_morsel = "complies with the Multibag BagIt profile"
 ABOUT_MBAG = "This bag {0}.  For more information, refer to the URL given by Multibag-Reference tag." \
              .format(_about_mbag_morsel)
 
+ispy2 = sys.version_info.major == 2
+
 class MemberInfo(object):
     """
     a description of a member bag of a multibag aggregation as given by a 
@@ -436,7 +438,7 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
         with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for mi in self._memberbags:
                 out = mi.format()
-                if isinstance(out, str):
+                if ispy2 and isinstance(out, str):
                     out = out.decode(DEF_ENC)
                 fd.write(out)
 
@@ -611,11 +613,12 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
                                'file-lookup.tsv')
         with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for item in self._filelu.items():
-                item = list(item)
-                if isinstance(item[0], str):
-                    item[0] = item[0].decode(DEF_ENC)
-                if isinstance(item[1], str):
-                    item[1] = item[1].decode(DEF_ENC)
+                if ispy2:
+                    item = list(item)
+                    if isinstance(item[0], str):
+                        item[0] = item[0].decode(DEF_ENC)
+                    if isinstance(item[1], str):
+                        item[1] = item[1].decode(DEF_ENC)
                 fd.write(u"{0}\t{1}\n".format(item[0], item[1]))
 
     def clear_file_lookup(self):

--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -435,7 +435,10 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
                                'member-bags.tsv')
         with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for mi in self._memberbags:
-                fd.write(mi.format())
+                out = mi.format()
+                if isinstance(out, str):
+                    out = out.decode(DEF_ENC)
+                fd.write(out)
 
     def lookup_file(self, filepath, reread=False):
         """
@@ -670,7 +673,7 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
         self.ensure_tagdir()
         with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for path in self._deleted:
-                fd.write(path + "\n")
+                fd.write(path + u"\n")
 
     def update_info(self, version=None, profver=CURRENT_VERSION):
         """

--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -3,14 +3,14 @@ This module provides access to the informational content of a multibag
 aggregation.  In particular, it provides the read-only HeadBag class.
 """
 from __future__ import absolute_import
-import re, os, sys
+import re, os, sys, io
 from collections import OrderedDict
 
 from .bagit import Bag, ReadOnlyBag, open_bag
 from .exceptions import MultibagError, MissingMultibagFileError
 from .extended import (ExtendedReadMixin, ExtendedReadOnlyBag,
                        ExtendedReadWritableBag, as_extended)
-from ..constants import CURRENT_VERSION, CURRENT_REFERENCE, Version
+from ..constants import CURRENT_VERSION, CURRENT_REFERENCE, Version, DEF_ENC
 
 if sys.version_info[0] > 2:
     _unicode = str
@@ -433,7 +433,7 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
         self.ensure_tagdir()
         tagfile = os.path.join(self._bagdir, self.multibag_tag_dir,
                                'member-bags.tsv')
-        with open(tagfile, 'w') as fd:
+        with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for mi in self._memberbags:
                 fd.write(mi.format())
 
@@ -606,9 +606,9 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
         self.ensure_tagdir()
         tagfile = os.path.join(self._bagdir, self.multibag_tag_dir,
                                'file-lookup.tsv')
-        with open(tagfile, 'w') as fd:
+        with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for item in self._filelu.items():
-                fd.write("{0}\t{1}\n".format(item[0], item[1]))
+                fd.write(u"{0}\t{1}\n".format(item[0], item[1]))
 
     def clear_file_lookup(self):
         """
@@ -668,7 +668,7 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
             os.remove(tagfile)
 
         self.ensure_tagdir()
-        with open(tagfile, 'w') as fd:
+        with io.open(tagfile, 'w', encoding=DEF_ENC) as fd:
             for path in self._deleted:
                 fd.write(path + "\n")
 

--- a/multibag/constants.py
+++ b/multibag/constants.py
@@ -7,6 +7,7 @@ CURRENT_VERSION = "0.4"
 CURRENT_REFERENCE = "https://github.com/usnistgov/multibag-py/blob/master/docs/multibag-profile-spec.md"
 
 DEFAULT_TAG_DIR = "multibag"
+DEF_ENC = 'utf-8'
 
 if sys.version_info[0] > 2:
     _unicode = str

--- a/multibag/restore.py
+++ b/multibag/restore.py
@@ -1,10 +1,10 @@
 """
 functions for restoring a bag from its multibag components.
 """
-import os, sys, re, shutil, io, time, errno
+import os, sys, re, shutil, io, time, errno, io
 from collections import OrderedDict
 
-from .constants import CURRENT_VERSION as MBAG_VERSION
+from .constants import CURRENT_VERSION as MBAG_VERSION, DEF_ENC
 from .access.bagit import Bag, ReadOnlyBag
 from .access.multibag import (is_headbag, as_headbag, open_headbag, MissingMultibagFileError,
                               HeadBag, ReadOnlyHeadBag, MultibagError, ExtendedReadWritableBag)
@@ -243,13 +243,15 @@ class BagRestorer(object):
         for alg in updated_by_alg:
             files = [f for f in updated_by_alg[alg].keys() if f.startswith("data/")]
             if len(files) > 0:
-                with open(os.path.join(self._destdir, "manifest-%s.txt" % alg), 'w') as fd:
+                mfp = os.path.join(self._destdir, "manifest-%s.txt" % alg)
+                with io.open(mfp, 'w', encoding=DEF_ENC) as fd:
                     for f in files:
                         fd.write("%s %s\n" % (updated_by_alg[alg][f], f))
 
             files = [f for f in updated_by_alg[alg].keys() if not f.startswith("data/")]
             if len(files) > 0:
-                with open(os.path.join(self._destdir, "tagmanifest-%s.txt" % alg), 'w') as fd:
+                mfp = os.path.join(self._destdir, "tagmanifest-%s.txt" % alg)
+                with io.open(mfp, 'w', encoding=DEF_ENC) as fd:
                     for f in files:
                         fd.write("%s %s\n" % (updated_by_alg[alg][f], f))
 
@@ -274,7 +276,8 @@ class BagRestorer(object):
                         if len(parts) > 1 and parts[1]:
                             fetch[parts[1]] = line
         if fetch:
-            with open(os.path.join(self._destdir, "fetch.txt"), 'w') as fd:
+            fp = os.path.join(self._destdir, "fetch.txt")
+            with io.open(fp, 'w', encoding=DEF_ENC) as fd:
                 for f in fetch:
                     fd.write(fetch[f])
 
@@ -291,7 +294,8 @@ class BagRestorer(object):
         if self._head.isfile("multibag/aggregation-info.txt"):
             with self._head.open_text_file("multibag/aggregation-info.txt") as fd:
                 content = fd.read()
-            with open(os.path.join(self._destdir, "bag-info.txt"), 'w') as fd:
+            bif = os.path.join(self._destdir, "bag-info.txt")
+            with io.open(bif, 'w', encoding=DEF_ENC) as fd:
                 fd.write(content)
                     
         if not self._inplace:

--- a/multibag/split.py
+++ b/multibag/split.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from functools import cmp_to_key
 
-from .constants import CURRENT_VERSION as MBAG_VERSION
+from .constants import CURRENT_VERSION as MBAG_VERSION, DEF_ENC
 from .access.bagit import Bag, ReadOnlyBag
 from .access.multibag import as_headbag, MissingMultibagFileError
 from .access.extended import as_extended, ExtendedReadMixin as ProgenitorMixin
@@ -278,7 +278,8 @@ class SplitPlan(object):
 
             # create empty manifest files
             for mf in self.progenitor.manifest_files():
-                with open(os.path.join(bagdir, os.path.basename(mf)), 'w') as fd:
+                mfp = os.path.join(bagdir, os.path.basename(mf))
+                with io.open(mfp, 'w', encoding=DEF_ENC) as fd:
                     pass
 
             self.progenitor.replicate("bagit.txt", bagdir)
@@ -333,7 +334,7 @@ class SplitPlan(object):
                     
             # create the bag-info file
             outinfo = os.path.join(bagdir, "bag-info.txt")
-            with io.open(outinfo, 'w', encoding='utf-8') as fd:
+            with io.open(outinfo, 'w', encoding=DEF_ENC) as fd:
                 _write_item(fd, 'Multibag-Version', MBAG_VERSION)
                 for name, vals in self.progenitor.info.items():
                     if name.startswith('Multibag-'):
@@ -380,16 +381,16 @@ class SplitPlan(object):
                     os.mkdir(mbagdir)
 
                 with io.open(os.path.join(mbagdir, "member-bags.tsv"),
-                             'w', encoding='utf-8') as fd:
+                             'w', encoding=DEF_ENC) as fd:
                     for bag in memberbags:
                         fd.write(u"%s" % bag)
                         fd.write(u'\n')
                 with io.open(os.path.join(mbagdir, "file-lookup.tsv"),
-                             'w', encoding='utf-8') as fd:
+                             'w', encoding=DEF_ENC) as fd:
                     for f in filedest:
                         fd.write(u"%s\t%s\n" % (f, filedest[f]))
                 with io.open(os.path.join(mbagdir, "aggregation-info.txt"),
-                             'w', encoding='utf-8') as fd:
+                             'w', encoding=DEF_ENC) as fd:
                     with self.progenitor.open_text_file("bag-info.txt") as ifd:
                         for f in ifd:
                             fd.write(f)
@@ -406,7 +407,7 @@ class SplitPlan(object):
         manpath = os.path.join(outdir, manfile)
         if not os.path.exists(manpath):
             open(manpath, 'w').close()
-        with io.open(manpath, 'a', encoding='utf-8') as fd:
+        with io.open(manpath, 'a', encoding=DEF_ENC) as fd:
             fd.write(hash)
             fd.write(u' ')
             fd.write(path)

--- a/tests/multibag/access/test_multibag.py
+++ b/tests/multibag/access/test_multibag.py
@@ -558,6 +558,18 @@ class TestReadWriteHeadBag(test.TestCase):
             [ "data/gurn/goober.json", "samplembag2" ]
         ])
 
+        self.bag.add_file_lookup(b"data/trial\xce\xb1.tiff", b"samplebag")
+        self.bag.save_file_lookup()
+        with io.open(lufile, encoding='utf-8') as fd:
+            items = [line.strip().split('\t') for line in fd]
+        self.assertEqual(items, [
+            [ "data/trial1.json", "samplembag" ],
+            [ "data/gurn/goober.json", "samplembag2" ],
+            [ u"data/trial\u03b1.tiff", "samplebag"]
+        ])
+        self.assertTrue(isinstance(items[0][0], unicode))
+        
+
     def test_set_deleted(self):
         tagdir = os.path.join(self.bagdir, "multibag")
         delfile = os.path.join(tagdir, "deleted.txt")

--- a/tests/multibag/access/test_multibag.py
+++ b/tests/multibag/access/test_multibag.py
@@ -487,7 +487,7 @@ class TestReadWriteHeadBag(test.TestCase):
         self.assertEqual(names, ["samplembag","samplembag2"])
         
         self.clear_multibag()
-        self.bag.add_member_bag(b"samplembag2")
+        self.bag.add_member_bag(b"samplembag2" if mb.ispy2 else "samplembag2")
         self.assertEqual(self.bag.member_bag_names, ["samplembag2"])
         self.bag.save_member_bags()
         with io.open(os.path.join(self.bagdir, "multibag","member-bags.tsv"), encoding='utf-8') as fd:
@@ -558,7 +558,8 @@ class TestReadWriteHeadBag(test.TestCase):
             [ "data/gurn/goober.json", "samplembag2" ]
         ])
 
-        self.bag.add_file_lookup(b"data/trial\xce\xb1.tiff", b"samplebag")
+        fname = b"data/trial\xce\xb1.tiff" if mb.ispy2 else "data/trial\u03b1.tiff"
+        self.bag.add_file_lookup(fname, "samplebag")
         self.bag.save_file_lookup()
         with io.open(lufile, encoding='utf-8') as fd:
             items = [line.strip().split('\t') for line in fd]
@@ -567,7 +568,8 @@ class TestReadWriteHeadBag(test.TestCase):
             [ "data/gurn/goober.json", "samplembag2" ],
             [ u"data/trial\u03b1.tiff", "samplebag"]
         ])
-        self.assertTrue(isinstance(items[0][0], unicode))
+        if mb.ispy2:
+            self.assertTrue(isinstance(items[0][0], unicode))
         
 
     def test_set_deleted(self):

--- a/tests/multibag/access/test_multibag.py
+++ b/tests/multibag/access/test_multibag.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os, pdb, logging
+import os, pdb, logging, io
 import tempfile, shutil
 import unittest as test
 from collections import OrderedDict
@@ -487,12 +487,19 @@ class TestReadWriteHeadBag(test.TestCase):
         self.assertEqual(names, ["samplembag","samplembag2"])
         
         self.clear_multibag()
-        self.bag.add_member_bag("samplembag2")
+        self.bag.add_member_bag(b"samplembag2")
         self.assertEqual(self.bag.member_bag_names, ["samplembag2"])
         self.bag.save_member_bags()
-        with open(os.path.join(self.bagdir, "multibag","member-bags.tsv")) as fd:
+        with io.open(os.path.join(self.bagdir, "multibag","member-bags.tsv"), encoding='utf-8') as fd:
             names = [line.strip() for line in fd]
         self.assertEqual(names, ["samplembag2"])
+
+        self.bag.add_member_bag(u"samplebag\u03b1")
+        self.bag.save_member_bags()
+        with io.open(os.path.join(self.bagdir, "multibag","member-bags.tsv"), encoding='utf-8') as fd:
+            names = [line.strip() for line in fd]
+        self.assertEqual(names, [u"samplembag2", u"samplebag\u03b1"])
+        
 
     def test_add_file_lookup(self):
         self.assertEqual(self.bag.lookup_file("data/trial1.json"), "samplembag")

--- a/tests/multibag/access/test_multibag.py
+++ b/tests/multibag/access/test_multibag.py
@@ -523,6 +523,12 @@ class TestReadWriteHeadBag(test.TestCase):
         self.bag.save_file_lookup()
         self.assertIsNone(self.bag.lookup_file("data/trial1.json", reread=True))
 
+        self.bag._filelu[u'data/trial\u03b1.json'] = 'samplembag3'
+        self.bag.save_file_lookup()
+        self.assertEqual(self.bag.lookup_file(u"data/trial\u03b1.json", reread=True),
+                         "samplembag3")
+        
+
     def test_save_file_lookup(self):
         self.clear_multibag()
         tagdir = os.path.join(self.bagdir, "multibag")


### PR DESCRIPTION
This PR fixes failures writing some text files (like manifest files and the `file-lookup.tsv` file) that occur when data files include non-ascii characters in their names.  This PR ensures that these files are written with UTF-8 encoding to support unicode characters (including greek letters). 

