### PR TITLE
Support python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
+os: linux
+dist: focal
+arch: amd64
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
   - "3.8"
   - "3.9"
+  - "3.10"
 install:
   - pip install -r requirements.txt
 

--- a/multibag/validate/base.py
+++ b/multibag/validate/base.py
@@ -2,7 +2,11 @@
 This module provides base classes and infrastructure for multibag validation
 """
 import sys
-from collections import Sequence, OrderedDict
+from collections import OrderedDict
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from ..constants import CURRENT_VERSION
 from ..access.bagit import BagValidationError, BagError, open_bag

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bagit>=1.6.0
 setuptools
 fs>=2.0.0
 funcsigs>=1.0.2; python_version < '3.0'
+mock


### PR DESCRIPTION
This PR required one code fix to support python 3.6:  a 2.7-compatible loading of the Sequence type.  Travis config file updated to test. (Dropped testing on python 3.5-3.7.)