### PR TITLE
Fix unicode file lookup error

### DIFF
--- a/multibag/access/multibag.py
+++ b/multibag/access/multibag.py
@@ -275,6 +275,8 @@ class HeadBagReadMixin(ExtendedReadMixin):
         """
         if reread or self._filelu is None:
             self._cache_file_lookup()
+        if ispy2 and isinstance(filepath, str):
+            filepath = filepath.decode(DEF_ENC)
         return self._filelu.get(filepath)
 
     def files_in_member(self, bagname):
@@ -469,6 +471,8 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
            not isinstance(bagname, (str, _unicode)):
             raise TypeError("input arguments must be strings: " +
                             str( (filepath, bagname,) ))
+        if ispy2 and isinstance(filepath, str):
+            filepath = filepath.decode(DEF_ENC)  # or the dict key won't match
         if self._filelu is None:
             try:
                 self._cache_file_lookup()
@@ -488,6 +492,8 @@ class HeadBagUpdateMixin(HeadBagReadMixin):
                 self._cache_file_lookup()
             except MissingMultibagFileError:
                 return
+        if ispy2 and isinstance(filepath, str):
+            filepath = filepath.decode(DEF_ENC)  # or the dict key won't match
         if filepath in self._filelu:
             del self._filelu[filepath]
 


### PR DESCRIPTION
Previous PR #23 improved support for unicode filenames, mainly involving fixing how the special multibag files--`multibag/member_bags.tsv` and `multibag/file_lookup.tsv`--get written; this follow-on PR fixes an error under python 2.7 looking up names from the latter file.  When the default encoding is UTF-8, the `str` and `unicode` versions of a filename do not hash to the same value (unlike with ASCII encoding).  This caused errors looking up filenames from the in-memory dictionary.  This PR, when running under python 2.7, ensures filenames are converted to unicode before doing lookups.
